### PR TITLE
Fix 500 error for addons that have not migrated to external accounts

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -139,6 +139,10 @@ class UserAddonSettingsSerializer(JSONAPISerializer):
         )
 
     def account_links(self, obj):
+        if not hasattr(obj, 'external_accounts'):
+            # FIXME: Forcibly excludes addons not yet migrated to new addon structure
+            return {}
+
         return {
             account._id: {
                 'account': absolute_reverse('users:user-external_account-detail', kwargs={'user_id': obj.owner._id, 'provider': obj.config.short_name, 'account_id': account._id}),


### PR DESCRIPTION
While trying to manually test osf.io/#5532, encountered an error. This implements the fix discussed with @mfraezz via flowdock; I have not run tests on this yet. The page does load with the fix- it simply excludes the "Accounts" field from links section entirely.

Error report below:

Tried to manually test, and got this error at `/v2/users/me/addons/`, for a user with one of basically everything connected to a project.

```
AttributeError: AddonFigShareUserSettings object has no attribute external_accounts
[06/May/2016 13:24:56] "GET /v2/users/me/addons/ HTTP/1.1" 500 59
```

Matt indicates that figshare had not yet been migrated to the new external accounts structure.