### PR TITLE
Feature/Preprint GUID improvements

### DIFF
--- a/api/preprints/parsers.py
+++ b/api/preprints/parsers.py
@@ -3,11 +3,12 @@ from api.base.parsers import JSONAPIParser, JSONAPIParserForRegularJSON
 
 class PreprintsJSONAPIParser(JSONAPIParser):
     def flatten_relationships(self, relationships):
-        ret = super(PreprintsJSONAPIParser, self).flatten_relationships(relationships)
-        related_resource = relationships.keys()[0]
-        if ret.get('target_type') and ret.get('id'):
-            return {related_resource: ret['id']}
-        return ret
+        rel = {}
+        for resource in relationships:
+            ret = super(PreprintsJSONAPIParser, self).flatten_relationships({resource: relationships[resource]})
+            if ret.get('target_type') and ret.get('id'):
+                rel[resource] = ret['id']
+        return rel
 
 
 class PreprintsJSONAPIParserForRegularJSON(JSONAPIParserForRegularJSON):

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -50,7 +50,7 @@ class PreprintSerializer(JSONAPISerializer):
         'is_published',
     ])
 
-    id = IDField(source='_id', required=False)
+    id = IDField(source='_id', read_only=True)
     subjects = JSONAPIListField(child=JSONAPIListField(child=TaxonomyField()), required=False)
     provider = ser.CharField(required=False)
     date_created = ser.DateTimeField(read_only=True)
@@ -144,8 +144,8 @@ class PreprintSerializer(JSONAPISerializer):
             self.set_field(preprint.set_preprint_subjects, subjects, auth)
             save_preprint = True
 
-        if 'doi' in validated_data:
-            preprint.node.preprint_article_doi = validated_data['doi']
+        if 'preprint_article_doi' in validated_data:
+            preprint.node.preprint_article_doi = validated_data['preprint_article_doi']
             save_node = True
 
         published = validated_data.pop('is_published', None)


### PR DESCRIPTION
# Purpose

- Preserves multiple relationships so I can create a preprint with three relationships: primary_file, node, and provider.
-  Removes id from POST request
- DOI is `preprint_article_doi` in validated_data